### PR TITLE
Add docs for upsert items endpoint

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -83,6 +83,7 @@
                 "pages": [
                   "docs/content/overview",
                   "docs/content/fetch-items",
+                  "docs/content/upsert-items",
                   "docs/content/create-items",
                   "docs/content/update-items",
                   "docs/content/publish-items",

--- a/docs/content/upsert-items.mdx
+++ b/docs/content/upsert-items.mdx
@@ -1,0 +1,49 @@
+---
+title: "Upsert Items"
+openapi: "POST /api/v1/items/upsert"
+---
+
+## MatchOn Behavior
+
+The `matchOn` parameter can be provided either as a top-level property on the item object, or as a property within the `properties` array. If both are present, the top-level property takes precedence.
+
+For example, when using `matchOn: "iso2"`, you can provide the ISO code either as:
+```typescript
+{
+  "iso2": "SE",  // top-level property
+  "class_id": "Country",
+  // ...
+}
+```
+or as:
+```typescript
+{
+  "class_id": "Country",
+  "properties": [
+    { "id": "iso2", "statements": [{ "data_value": "SE" }] }  // property in array
+  ]
+}
+```
+
+## Property Update Behavior
+
+When updating items, the API handles properties in the following ways:
+
+- Properties not included in the update request are preserved
+- Properties included with statements are updated with the new values
+- Properties included with an empty statements array are deleted
+
+Example of property deletion:
+```typescript
+{
+  "data": [
+    {
+      "id": "sweden",
+      "class_id": "Country",
+      "properties": [
+        { "id": "population", "statements": [] } // This will delete the population property
+      ]
+    }
+  ]
+}
+```

--- a/openapi.json
+++ b/openapi.json
@@ -334,7 +334,7 @@
     "/api/v1/items/upsert": {
       "post": {
         "summary": "Upsert Items",
-        "description": "Create or update multiple items in a single operation. Items are matched using a specified key (matchOn) - if a match is found, the item is updated; if no match is found, a new item is created. The operation is atomic: all items are either processed successfully or none are.",
+        "description": "Create or update multiple items in a single operation. Items are matched using a specified key (matchOn) - if a match is found, the item is updated; if no match is found, a new item is created. This endpoint runs each batch in a single transaction—if any item fails, the entire batch is rolled back, so either all items succeed or none do.",
         "operationId": "upsertItems",
         "requestBody": {
           "required": true,

--- a/openapi.json
+++ b/openapi.json
@@ -330,6 +330,172 @@
           }
         }
       }
+    },
+    "/api/v1/items/upsert": {
+      "post": {
+        "summary": "Upsert Items",
+        "description": "Create or update multiple items in a single operation. Items are matched using a specified key (matchOn) - if a match is found, the item is updated; if no match is found, a new item is created. The operation is atomic: all items are either processed successfully or none are.",
+        "operationId": "upsertItems",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/ItemInput" }
+                  },
+                  "matchOn": {
+                    "type": "string",
+                    "description": "The key used to match items with existing records. Can be a db-optimized property (e.g., id) or a statement property (e.g., iso2). If both a top-level property and a property in the properties array are present, the top-level property takes precedence.",
+                    "default": "id"
+                  },
+                  "preserveResponse": {
+                    "type": "boolean",
+                    "description": "Return raw database response instead of formatted items.",
+                    "default": false
+                  }
+                },
+                "required": ["data"]
+              },
+              "examples": {
+                "DefaultIdKey": {
+                  "summary": "Using default id key",
+                  "value": {
+                    "data": [
+                      {
+                        "class_id": "Country",
+                        "workspace_id": "datastory_cloud",
+                        "properties": [
+                          {
+                            "id": "name",
+                            "statements": [{ "data_value": { "en": "Sweden" } }]
+                          },
+                          {
+                            "id": "iso2",
+                            "statements": [{ "data_value": "SE" }]
+                          },
+                          {
+                            "id": "population",
+                            "statements": [{ "data_value": 10400000 }]
+                          }
+                        ]
+                      },
+                      {
+                        "id": "norway",
+                        "class_id": "Country",
+                        "workspace_id": "datastory_cloud",
+                        "properties": [
+                          {
+                            "id": "name",
+                            "statements": [
+                              { "data_value": { "en": "Kingdom of Norway" } }
+                            ]
+                          },
+                          {
+                            "id": "iso2",
+                            "statements": [{ "data_value": "NO" }]
+                          },
+                          {
+                            "id": "population",
+                            "statements": [{ "data_value": 5400000 }]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "CustomStatementProperty": {
+                  "summary": "Using custom statement property",
+                  "value": {
+                    "data": [
+                      {
+                        "class_id": "Country",
+                        "workspace_id": "datastory_cloud",
+                        "properties": [
+                          {
+                            "id": "name",
+                            "statements": [{ "data_value": { "en": "Sweden" } }]
+                          },
+                          {
+                            "id": "iso2",
+                            "statements": [{ "data_value": "SE" }]
+                          },
+                          {
+                            "id": "population",
+                            "statements": [{ "data_value": 10400000 }]
+                          }
+                        ]
+                      },
+                      {
+                        "class_id": "Country",
+                        "workspace_id": "datastory_cloud",
+                        "properties": [
+                          {
+                            "id": "name",
+                            "statements": [{ "data_value": { "en": "Norway" } }]
+                          },
+                          {
+                            "id": "iso2",
+                            "statements": [{ "data_value": "NO" }]
+                          },
+                          {
+                            "id": "population",
+                            "statements": [{ "data_value": 5400000 }]
+                          }
+                        ]
+                      }
+                    ],
+                    "matchOn": "iso2"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upserted items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          { "$ref": "#/components/schemas/FormattedItem" },
+                          { "$ref": "#/components/schemas/Item" }
+                        ]
+                      }
+                    }
+                  },
+                  "required": ["items"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -535,6 +701,212 @@
             "example": 60
           }
         }
+      },
+      "ItemInput": {
+        "type": "object",
+        "properties": {
+          "class_id": { "type": "string" },
+          "workspace_id": { "type": "string" },
+          "properties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartialFormattedItemProperty"
+            }
+          }
+        },
+        "additionalProperties": true,
+        "required": ["class_id", "workspace_id"]
+      },
+      "DataValueItem": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+              },
+              { "type": "string" }
+            ]
+          },
+          "slug": { "type": "string" }
+        },
+        "required": ["id", "name", "slug"]
+      },
+      "DataValue": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/DataValueItem" },
+          { "type": "number" },
+          { "type": "string" },
+          { "type": "boolean" },
+          { "type": "object", "additionalProperties": true },
+          { "type": "object", "additionalProperties": { "type": "string" } },
+          { "type": "null" }
+        ]
+      },
+      "FormattedItemStatementBase": {
+        "type": "object",
+        "properties": {
+          "data_value": { "$ref": "#/components/schemas/DataValue" },
+          "id": { "type": "string" },
+          "qualifiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormattedItemStatementQualifier"
+            }
+          }
+        },
+        "required": ["data_value"]
+      },
+      "FormattedItemStatementQualifier": {
+        "type": "object",
+        "properties": {
+          "data_value": { "$ref": "#/components/schemas/DataValue" },
+          "id": { "type": "string" }
+        },
+        "required": ["data_value"]
+      },
+      "FormattedItemStatement": {
+        "allOf": [
+          { "$ref": "#/components/schemas/FormattedItemStatementBase" },
+          {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FormattedItemProperty"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "FormattedItemProperty": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "statements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormattedItemStatementBase"
+            }
+          },
+          "schema": { "$ref": "#/components/schemas/ClassPropertySchema" }
+        },
+        "required": ["id", "statements", "schema"]
+      },
+      "FormattedItem": {
+        "title": "FormattedItem",
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "properties": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FormattedItemProperty" }
+          }
+        },
+        "required": ["id", "properties"]
+      },
+      "Item": {
+        "title": "Item",
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": {
+            "type": "object",
+            "properties": {
+              "en": { "type": "string" }
+            },
+            "additionalProperties": { "type": "string" },
+            "required": ["en"]
+          },
+          "nameEn": { "type": "string" },
+          "slug": { "type": "string" },
+          "class": {
+            "type": "object",
+            "properties": {
+              "nameEn": { "type": "string" }
+            },
+            "required": ["nameEn"]
+          },
+          "workspace": {
+            "type": "object",
+            "properties": {
+              "nameEn": { "type": "string" }
+            },
+            "required": ["nameEn"]
+          },
+          "class_id": { "type": "string" },
+          "workspace_id": { "type": "string" },
+          "publication_status": {
+            "type": ["string", "null"]
+          },
+          "semantic_type_id": { "type": "string" },
+          "postgres_column": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "name",
+          "nameEn",
+          "slug",
+          "class",
+          "workspace",
+          "class_id",
+          "workspace_id",
+          "semantic_type_id",
+          "postgres_column"
+        ]
+      },
+      "ClassPropertySchema": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "class_id": { "type": "string" },
+          "inherited_from_id": { "type": ["string", "null"] },
+          "is_db_optimized": { "type": ["boolean", "null"] },
+          "is_system_property": { "type": ["boolean", "null"] },
+          "is_single": { "type": "boolean" },
+          "max_count": { "type": ["number", "null"] },
+          "min_count": { "type": ["number", "null"] },
+          "position": { "type": ["number", "null"] },
+          "postgres_column": { "type": "string" },
+          "property_id": { "type": "string" },
+          "required": { "type": "boolean" },
+          "semantic_type_id": { "type": "string" },
+          "settings": {
+            "oneOf": [
+              { "type": "object", "additionalProperties": true },
+              { "type": "null" }
+            ]
+          },
+          "value_classes": {
+            "oneOf": [
+              { "type": "array", "items": { "type": "string" } },
+              { "type": "null" }
+            ]
+          },
+          "property_name": {
+            "type": "object",
+            "properties": {
+              "en": { "type": "string" }
+            },
+            "required": ["en"]
+          },
+          "inverse_of_id": { "type": ["string", "null"] },
+          "dimension_type_id": { "type": ["string", "null"] }
+        },
+        "required": [
+          "id",
+          "class_id",
+          "is_single",
+          "postgres_column",
+          "property_id",
+          "required",
+          "semantic_type_id",
+          "property_name"
+        ]
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -361,13 +361,14 @@
                 "required": ["data"]
               },
               "examples": {
-                "DefaultIdKey": {
+                "Match by ID": {
                   "summary": "Using default id key",
                   "value": {
                     "data": [
                       {
+                        "id": "sweden",
                         "class_id": "Country",
-                        "workspace_id": "datastory_cloud",
+                        "workspace_id": "open_data",
                         "properties": [
                           {
                             "id": "name",
@@ -380,40 +381,19 @@
                           {
                             "id": "population",
                             "statements": [{ "data_value": 10400000 }]
-                          }
-                        ]
-                      },
-                      {
-                        "id": "norway",
-                        "class_id": "Country",
-                        "workspace_id": "datastory_cloud",
-                        "properties": [
-                          {
-                            "id": "name",
-                            "statements": [
-                              { "data_value": { "en": "Kingdom of Norway" } }
-                            ]
-                          },
-                          {
-                            "id": "iso2",
-                            "statements": [{ "data_value": "NO" }]
-                          },
-                          {
-                            "id": "population",
-                            "statements": [{ "data_value": 5400000 }]
                           }
                         ]
                       }
                     ]
                   }
                 },
-                "CustomStatementProperty": {
+                "Match by Statement": {
                   "summary": "Using custom statement property",
                   "value": {
                     "data": [
                       {
                         "class_id": "Country",
-                        "workspace_id": "datastory_cloud",
+                        "workspace_id": "open_data",
                         "properties": [
                           {
                             "id": "name",
@@ -426,24 +406,6 @@
                           {
                             "id": "population",
                             "statements": [{ "data_value": 10400000 }]
-                          }
-                        ]
-                      },
-                      {
-                        "class_id": "Country",
-                        "workspace_id": "datastory_cloud",
-                        "properties": [
-                          {
-                            "id": "name",
-                            "statements": [{ "data_value": { "en": "Norway" } }]
-                          },
-                          {
-                            "id": "iso2",
-                            "statements": [{ "data_value": "NO" }]
-                          },
-                          {
-                            "id": "population",
-                            "statements": [{ "data_value": 5400000 }]
                           }
                         ]
                       }
@@ -579,52 +541,15 @@
       },
       "ErrorResponse": {
         "type": "object",
-        "description": "An error response from the API. More info [here]('/docs/api-reference/errors')",
+        "description": "Error response from the API",
         "properties": {
           "error": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "invalid_request_error",
-                  "not_found_error",
-                  "creation_error",
-                  "update_error",
-                  "deletion_error",
-                  "forbidden_error",
-                  "authentication_error"
-                ],
-                "default": "invalid_request_error",
-                "description": "The type of error returned."
-              },
-              "message": {
-                "type": "string",
-                "description": "A human-readable message providing more details about the error.",
-                "example": "Parameter error."
-              },
-              "params": {
-                "type": "array",
-                "description": "The specific request parameters associated with the error. May be omitted if the error message is generic enough to apply to multiple parameters.",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "param": {
-                      "type": "string",
-                      "description": "The parameter related to the error.",
-                      "example": "name"
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "A human-readable message providing more details about the error.",
-                      "example": "Name is required."
-                    }
-                  }
-                }
-              }
-            }
+            "type": "string",
+            "description": "Error message",
+            "example": "Missing required parameter `class_id`"
           }
-        }
+        },
+        "required": ["error"]
       },
       "Cube": {
         "type": "object",


### PR DESCRIPTION
Document the upsert items endpoint via a combined approach of openapi.json and mdx file. Provide additional information in the mdx file and reference the openapi.json file to avoid duplication.

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/a9c4b5e2-5bc5-4c6d-9318-6b08f6c2eee3" />

Worth noting, this is first public documentation for FormattedItem and Item, I took what we have currently in the typesecript types and translated to schema. We should definitely revisit them especially Item could use some more thinking through. I do wonder though how to best keep them in sync.

When working on this page it also became apparent that the separate repos setup is not ideal from the AI editor assistance POV. In the docs repo I don't have access to the codebase where the API is implemented (endpoints and methods), I had to manually copy over information from one to the other. I understand the Mintlify is very good at docs but having docs and codebase in the same repo would make it much easier to maintain. Imagine tweaking the method you can easily ask the assistant go ahead and update related docs.